### PR TITLE
feature/US17964-remove-sticky-sessions-for-load-test

### DIFF
--- a/IngressAPI/crds-kids-club-checkin-service.yml
+++ b/IngressAPI/crds-kids-club-checkin-service.yml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: kc-checkin-api-ingress
+  name: api-ingress
   namespace: api
   annotations:
     ingress.kubernetes.io/ingress.class: "nginx"
@@ -10,9 +10,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
-    nginx.ingress.kubernetes.io/session-cookie-name: "REALTIMESERVERID"
 spec:
   tls:
   - hosts:

--- a/IngressAPI/crds-kids-club-checkin-service.yml
+++ b/IngressAPI/crds-kids-club-checkin-service.yml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: api-ingress
+  name: kc-checkin-api-ingress
   namespace: api
   annotations:
     ingress.kubernetes.io/ingress.class: "nginx"


### PR DESCRIPTION
Temporary commit for testing load balancing. 

Will remove this if it encounters problems.

https://kubernetes.github.io/ingress-nginx/examples/affinity/cookie/