### PR TITLE
Upgrade nginx-ingress-controller to v0.31.1. Fixes US17003

### DIFF
--- a/Ingress/deployment.yml
+++ b/Ingress/deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: crds-ingress
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.31.1
         imagePullPolicy: Always
         resources:
           limits:

--- a/IngressAPI/deployment.yml
+++ b/IngressAPI/deployment.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: api-ingress
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.31.1
         imagePullPolicy: Always
         env:
         - name: POD_NAME

--- a/IngressAPI/identity-rules.yml
+++ b/IngressAPI/identity-rules.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: api
   annotations:
     ingress.kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
@@ -18,7 +18,7 @@ spec:
   - host: $API_HOST_NAME
     http:
       paths:
-      - path: /identity
+      - path: /identity(/|$)(.*)
         backend:
           serviceName: crds-identity-service
           servicePort: 80

--- a/IngressAPI/rules.yml
+++ b/IngressAPI/rules.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: api
   annotations:
     ingress.kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
@@ -19,43 +19,43 @@ spec:
   - host: $API_HOST_NAME
     http:
       paths:
-      - path: /golocal
+      - path: /golocal(/|$)(.*)
         backend:
           serviceName: crds-go-local-api-service
           servicePort: 80
-      - path: /fred
+      - path: /fred(/|$)(.*)
         backend:
           serviceName: fred-service
           servicePort: 80
-      - path: /attendance
+      - path: /attendance(/|$)(.*)
         backend:
           serviceName: attendance-service
           servicePort: 80
-      - path: /finance
+      - path: /finance(/|$)(.*)
         backend:
           serviceName: crds-finance-service
           servicePort: 80
-      - path: /event-checkin
+      - path: /event-checkin(/|$)(.*)
         backend:
           serviceName: crds-event-checkin-service
           servicePort: 80
-      - path: /auth
+      - path: /auth(/|$)(.*)
         backend:
           serviceName: crds-auth-service
           servicePort: 80
-      - path: /serve
+      - path: /serve(/|$)(.*)
         backend:
           serviceName: crds-serve-service
           servicePort: 80
-      - path: /search-index
+      - path: /search-index(/|$)(.*)
         backend:
           serviceName: crds-search-index-service
           servicePort: 80
-      - path: /video-service
+      - path: /video-service(/|$)(.*)
         backend:
           serviceName: crds-video-service
           servicePort: 80
-      - path: /graphql-gateway
+      - path: /graphql-gateway(/|$)(.*)
         backend:
           serviceName: crds-graphql-gateway
           servicePort: 80

--- a/IngressDashboard/deployment.yml
+++ b/IngressDashboard/deployment.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: dashboard-ingress
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.31.1
         imagePullPolicy: Always
         env:
         - name: POD_NAME


### PR DESCRIPTION
Ref [PR#138](https://github.com/crdschurch/crds-kubernetes/pull/138) for original comments and discussions

- Versions >0.31.0 support nginx v1.17.10
- Related CVE-2018-16843 CVE-2018-16844 were resolved in nginx-ingress tags 0.21.0 and 0.25.1 (latter was an upstream fix)

- Supporting [information](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md)
- Ref crds-dpt/cloudy-with-a-chance-of-k8s Epic [#7](https://dev.azure.com/crds-dpt/cloudy-with-a-chance-of-k8s/_workitems/edit/7/)

Fix rewrite rules to support ingress controller >v0.22.0
Upgrade other missed ingress controller rules with rewrite annotations