### PR TITLE
Added new logging daemon set

### DIFF
--- a/NewRelic/logging-daemonset.yml
+++ b/NewRelic/logging-daemonset.yml
@@ -1,0 +1,185 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: newrelic-logging
+  namespace: api
+automountServiceAccountToken: true
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluent-bit-read
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - pods
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluent-bit-read
+subjects:
+  - kind: ServiceAccount
+    name: newrelic-logging
+    namespace: api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-read
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: newrelic-logging
+  namespace: api
+  labels:
+    app.kubernetes.io/name: newrelic-logging
+    k8s-app: newrelic-logging
+    kubernetes.io/cluster-service: 'true'
+    name: newrelic-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      name: newrelic-logging
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/name: newrelic-logging
+        k8s-app: newrelic-logging
+        kubernetes.io/cluster-service: 'true'
+        name: newrelic-logging
+        version: v1
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: fluent-bit-config
+            defaultMode: 420
+        - name: varlog
+          hostPath:
+            path: /var
+            type: ''
+      containers:
+        - name: newrelic-logging
+          image: 'newrelic/newrelic-fluentbit-output:1.3.0'
+          command:
+            - /fluent-bit/bin/fluent-bit
+            - '-c'
+            - /fluent-bit/etc/fluent-bit.conf
+            - '-e'
+            - /fluent-bit/bin/out_newrelic.so
+          env:
+            - name: ENDPOINT
+              value: 'https://log-api.newrelic.com/log/v1'
+            - name: SOURCE
+              value: kubernetes
+            - name: LICENSE_KEY
+              value: ${NR_INSTALL_KEY}
+            - name: CLUSTER_NAME
+              value: ${KUBERNETES_SERVER_NAME}
+            - name: LOG_LEVEL
+              value: info
+            - name: PATH
+              value: /var/log/containers/*.log
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 250m
+              memory: 64Mi
+          volumeMounts:
+            - name: config
+              mountPath: /fluent-bit/etc
+            - name: varlog
+              mountPath: /var
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 10
+      dnsPolicy: ClusterFirst
+      serviceAccountName: newrelic-logging
+      serviceAccount: newrelic-logging
+      securityContext: {}
+      schedulerName: default-scheduler
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  revisionHistoryLimit: 10
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: fluent-bit-config
+  namespace: api
+  labels:
+    k8s-app: newrelic-logging
+data:
+  filter-kubernetes.conf: |
+    [FILTER]
+        Name record_modifier
+        Match *
+        Record cluster_name ${CLUSTER_NAME}
+
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        Kube_URL       https://kubernetes.default.svc.cluster.local:443
+        Merge_JSON_Log Off
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+
+    @INCLUDE input-kubernetes.conf
+    @INCLUDE output-newrelic.conf
+    @INCLUDE filter-kubernetes.conf
+  input-kubernetes.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+  output-newrelic.conf: |
+    [OUTPUT]
+        Name  newrelic
+        Match *
+        licenseKey ${LICENSE_KEY}
+        endpoint ${ENDPOINT}
+  parsers.conf: |
+    [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+        # Command      |  Decoder | Field | Optional Action
+        # =============|==================|=================
+        Decode_Field_As   escaped    log
+
+  


### PR DESCRIPTION
Added a new Yaml config for New Relic Logging. The daemon file contains the yaml to configure:
- Service Account
- Daemon Set
- Cluster Role
- Cluster Role Binding
- Fluent D config Map

All of the configurations listed above combine to add a new-relic-logging pod to all the nodes in the cluster. The pods exist in the API name-space. The pod will pull all off the logs off of the nodes and send them to New Relic to aggregate our logging.

I have applied the file to the prod cluster, it already exist in INT, so we do not need to kick off the K8s project in Team City.