### PR TITLE
Updated the repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This namespace is built into the kubernetes deployment and contains some system 
 
 
 ### Updating SSL Certificates
+### This was the process prior to 1/1/21
 
 To update SSL Certificates:
 SSH into the Linux Build VM
@@ -32,3 +33,8 @@ Update the `chain.crt`, `tls.crt`, `tls.key` files under /data/teamcity/ssl - `s
 Redeploy the Kubernetes project in TeamCity
 
 Delete and restart the api-ingress pods
+
+### Updating SSL CERTS post 1/1/21
+The CertManager deployment downloads a cert manager from github and adds new k8s types. Then applies all of the files needed to automates the cert renewal process through letsencrypt. The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.
+
+The automation was added to all the k8s environments, but currently is only creating certs for the api ingress.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ Delete and restart the api-ingress pods
 ### Updating SSL CERTS post 1/1/21 ###
 The CertManager deployment downloads a cert manager from github and adds new k8s types. Then applies all of the files needed to automates the cert renewal process through letsencrypt. The cert information is stored on a volume with in the cluster.
 
- The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.
+The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.
 
-The automation was added to all the k8s environments, but currently is only creating certs for the api ingress.
+The automation was added to all the k8s environments, but currently is only creating certs for the api ingress. [Extra Documentation](https://docs.google.com/document/d/1xe6fGtLWx_ZJAU6UTK7QMf6343HRHr3f-YuppC3rGrM/edit?usp=sharing)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This namespace is built into the kubernetes deployment and contains some system 
 
 
 ### Updating SSL Certificates
-### This was the process prior to 1/1/21
+This was the process to update certs prior to automation added in Jan 21. The current certs stored in this location expire Oct 2021.
 
 To update SSL Certificates:
 SSH into the Linux Build VM
@@ -34,7 +34,7 @@ Redeploy the Kubernetes project in TeamCity
 
 Delete and restart the api-ingress pods
 
-### Updating SSL CERTS post 1/1/21
+### Updating SSL CERTS post 1/1/21 ###
 The CertManager deployment downloads a cert manager from github and adds new k8s types. Then applies all of the files needed to automates the cert renewal process through letsencrypt. The cert information is stored on a volume with in the cluster.
 
  The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Redeploy the Kubernetes project in TeamCity
 Delete and restart the api-ingress pods
 
 ### Updating SSL CERTS post 1/1/21
-The CertManager deployment downloads a cert manager from github and adds new k8s types. Then applies all of the files needed to automates the cert renewal process through letsencrypt. The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.
+The CertManager deployment downloads a cert manager from github and adds new k8s types. Then applies all of the files needed to automates the cert renewal process through letsencrypt. The cert information is stored on a volume with in the cluster.
+
+ The api-ssl-issuer.yml file is applied as a part of the crds-kubernetes deployment.
 
 The automation was added to all the k8s environments, but currently is only creating certs for the api ingress.


### PR DESCRIPTION
I added information to track how the ssl certs are being automated with the new cert manager and letsencrypt. 

Our currents certs do not expire till 10/21, so there is a small chance that the automation will not work as planned once the current certs expire. Because of this I decided to leave the old steps on how to manually update the certs. 